### PR TITLE
fix(helm): separate annotations

### DIFF
--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -55,6 +55,7 @@ service:
     enabled: false
     port: 8888
     nodePort: 38888
+    annotations: {}
   annotations: {}
   labels: {}
   


### PR DESCRIPTION
You might want different annotations for the two generated services